### PR TITLE
[WIP] fix ci and lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go 1.17
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
       id: go
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go 1.17
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
     - name: Check out code into the Go module directory

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
 
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
       - name: Install Protoc 3rd party protos

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
       id: go
     - name: Install Dependencies
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
     - uses: actions/cache@master
       with:
         path: ~/.cache/pip
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - uses: actions/cache@master
         with:
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - uses: actions/cache@master
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-grpc",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "gRPC for Wechaty",
   "type": "module",
   "exports": {


### PR DESCRIPTION
upgrade go version for one package (logsink?) reqires 1.18
![image](https://github.com/wechaty/grpc/assets/13669999/6cbde1d1-b133-4953-8414-94f9cb8263de)
